### PR TITLE
闪退bug检查

### DIFF
--- a/Base.h
+++ b/Base.h
@@ -52,12 +52,6 @@ namespace Base {
 	namespace World {
 		//环境生物
 		namespace EnvironmentalData {
-			//缓存数据
-			namespace TempData {
-				void* t_environmental = nullptr;
-				vector<void*> t_environmentalMessages;
-			}
-
 			struct EnvironmentalData {
 				void* Plot = nullptr;
 				float CoordinatesX = 0;
@@ -803,31 +797,15 @@ namespace Base {
 						);
 						return original(x1, x2);
 					});
-				/*
 				//环境生物地址获取
 				HookLambda(MH::EnvironmentalBiological::ctor,
-					[](auto rcx, auto rdx, auto r8, auto r9) {
-						Base::World::EnvironmentalData::TempData::t_environmental = rcx;
-						return original(rcx, rdx, r8, r9);
+					[](auto environmental, auto id, auto subId) {
+						auto ret = original(environmental, id, subId);
+						Base::World::EnvironmentalData::Environmentals[environmental] = Base::World::EnvironmentalData::EnvironmentalData(
+							environmental, 0, 0, 0, id, subId
+						);
+						return ret;
 					});
-				HookLambda(MH::EnvironmentalBiological::ctor_,
-					[](auto unkn1) {
-						bool addEnvironmental = true;
-						vector<void*>::iterator it;
-						for (it = Base::World::EnvironmentalData::TempData::t_environmentalMessages.begin(); 
-							it != Base::World::EnvironmentalData::TempData::t_environmentalMessages.end(); 
-							it++
-							)
-						{
-							if (*it == Base::World::EnvironmentalData::TempData::t_environmental)
-								addEnvironmental = false;
-						}
-						if (addEnvironmental)
-							Base::World::EnvironmentalData::TempData::t_environmentalMessages.push_back(
-							Base::World::EnvironmentalData::TempData::t_environmental);
-						return original(unkn1);
-					});
-				*/
 				//怪物地址获取
 				HookLambda(MH::Monster::ctor,
 					[](auto monster, auto id, auto subId) {
@@ -896,7 +874,6 @@ namespace Base {
 				//清除计时器数据
 				Chronoscope::ChronoscopeList.clear();
 				//清除环境生物数据
-				World::EnvironmentalData::TempData::t_environmentalMessages.clear();
 				World::EnvironmentalData::Environmentals.clear();
 				//清除相机数据
 				PlayerData::Coordinate::TempData::t_SetVisualBind = nullptr;
@@ -918,37 +895,18 @@ namespace Base {
 			}
 			//更新玩家数据
 			PlayerData::Updata();
-			//清除死亡的环境生物
+			//清除死亡的环境生物,此处最好能找到环境生物吊销的地址，目前先这样用着
 			for (auto [Environmental, EData] : World::EnvironmentalData::Environmentals) {
 				if (EData.Plot == nullptr) {
 					World::EnvironmentalData::Environmentals.erase(Environmental);
 				}
 			}
 			//更新环境生物数据
-			vector<void*>::iterator it;
-			for (it = World::EnvironmentalData::TempData::t_environmentalMessages.begin(); it != World::EnvironmentalData::TempData::t_environmentalMessages.end(); it++)
-			{
-				if (*it != nullptr) {
-					if (Base::World::EnvironmentalData::Environmentals.find(*it) == Base::World::EnvironmentalData::Environmentals.end()) {
-						Base::World::EnvironmentalData::Environmentals[*it] = 
-						Base::World::EnvironmentalData::EnvironmentalData(
-							*it,
-							0,
-							0, 
-							0,
-							*offsetPtr<int>(*it, 0x1AF0),
-							*offsetPtr<int>(*it, 0x1AF4)
-						);
-					}
-					else {
-						//如果生物存在列表中就只更新坐标数据
-						Base::World::EnvironmentalData::Environmentals[*it].CoordinatesX = *offsetPtr<float>(*it, 0x160);
-						Base::World::EnvironmentalData::Environmentals[*it].CoordinatesY = *offsetPtr<float>(*it, 0x164);
-						Base::World::EnvironmentalData::Environmentals[*it].CoordinatesZ = *offsetPtr<float>(*it, 0x168);
-					}
-				}
-				else {
-					World::EnvironmentalData::TempData::t_environmentalMessages.erase(it);
+			for (auto [environmental, environmentalData] : Base::World::EnvironmentalData::Environmentals) {
+				if (environmental != nullptr) {
+					Base::World::EnvironmentalData::Environmentals[environmental].CoordinatesX = *offsetPtr<float>(environmental, 0x160);
+					Base::World::EnvironmentalData::Environmentals[environmental].CoordinatesY = *offsetPtr<float>(environmental, 0x164);
+					Base::World::EnvironmentalData::Environmentals[environmental].CoordinatesZ = *offsetPtr<float>(environmental, 0x168);
 				}
 			}
 			//更新怪物信息

--- a/Base.h
+++ b/Base.h
@@ -569,8 +569,13 @@ namespace Base {
 			if (ActionPlot != nullptr) {
 				ActionId = *offsetPtr<int>(ActionPlot, 0xE9C4);
 				void* HookOffset1 = *offsetPtr<undefined**>((undefined(*)())ActionPlot, 0x70);
-				void* HookOffset2 = *offsetPtr<undefined**>((undefined(*)())HookOffset1, 0x10);
-				void* HookOffset3 = *offsetPtr<undefined**>((undefined(*)())HookOffset2, 0x18);
+				void* HookOffset2 = nullptr;
+				if(HookOffset1 != nullptr)
+					HookOffset2 = *offsetPtr<undefined**>((undefined(*)())HookOffset1, 0x10);
+				void* HookOffset3 = nullptr;
+				if (HookOffset2 != nullptr)
+					HookOffset3 = *offsetPtr<undefined**>((undefined(*)())HookOffset2, 0x18);
+				if (HookOffset3 != nullptr)
 				Coordinate::Hook = Vector3(
 					*offsetPtr<float>(HookOffset3, 0x160),
 					*offsetPtr<float>(HookOffset3, 0x164),

--- a/Base.h
+++ b/Base.h
@@ -910,8 +910,8 @@ namespace Base {
 				BasicGameData::PlayerPlot = *offsetPtr<undefined**>((undefined(*)())PlayerPlot, 0x50);
 			}
 			//更新玩家数据
-			PlayerData::Updata();
 			/*
+			PlayerData::Updata();
 			//清除死亡的环境生物
 			for (auto [Environmental, EData] : World::EnvironmentalData::Environmentals) {
 				if (EData.Plot == nullptr) {
@@ -953,7 +953,6 @@ namespace Base {
 					Base::Monster::Monsters[monster].CoordinatesZ = *offsetPtr<float>(monster, 0x168);
 				}
 			}
-			*/
 			//更新计时器时间
 			Chronoscope::NowTime = *offsetPtr<float>(BasicGameData::MapPlot, 0xC24);
 			//检查相机计时器
@@ -974,6 +973,7 @@ namespace Base {
 			}
 			//运行委托
 			Commission::Run();
+			*/
 		}
 	}
 }

--- a/Base.h
+++ b/Base.h
@@ -911,6 +911,7 @@ namespace Base {
 			}
 			//更新玩家数据
 			PlayerData::Updata();
+			/*
 			//清除死亡的环境生物
 			for (auto [Environmental, EData] : World::EnvironmentalData::Environmentals) {
 				if (EData.Plot == nullptr) {
@@ -952,6 +953,7 @@ namespace Base {
 					Base::Monster::Monsters[monster].CoordinatesZ = *offsetPtr<float>(monster, 0x168);
 				}
 			}
+			*/
 			//更新计时器时间
 			Chronoscope::NowTime = *offsetPtr<float>(BasicGameData::MapPlot, 0xC24);
 			//检查相机计时器

--- a/Base.h
+++ b/Base.h
@@ -775,7 +775,10 @@ namespace Base {
 
 	//初始化
 	static bool Init() {
-		if (!ModConfig::GameDataInit) {
+		if (ModConfig::GameDataInit) 
+			return true;
+		else
+		{
 			void* PlayerPlot = *(undefined**)MH::Player::PlayerBasePlot;
 			void* PlayerInfoPlot = *(undefined**)MH::Player::BasePtr;
 			BasicGameData::PlayerPlot = *offsetPtr<undefined**>((undefined(*)())PlayerPlot, 0x50);
@@ -800,6 +803,7 @@ namespace Base {
 						);
 						return original(x1, x2);
 					});
+				/*
 				//环境生物地址获取
 				HookLambda(MH::EnvironmentalBiological::ctor,
 					[](auto rcx, auto rdx, auto r8, auto r9) {
@@ -810,15 +814,20 @@ namespace Base {
 					[](auto unkn1) {
 						bool addEnvironmental = true;
 						vector<void*>::iterator it;
-						for (it = Base::World::EnvironmentalData::TempData::t_environmentalMessages.begin(); it != Base::World::EnvironmentalData::TempData::t_environmentalMessages.end(); it++)
+						for (it = Base::World::EnvironmentalData::TempData::t_environmentalMessages.begin(); 
+							it != Base::World::EnvironmentalData::TempData::t_environmentalMessages.end(); 
+							it++
+							)
 						{
 							if (*it == Base::World::EnvironmentalData::TempData::t_environmental)
 								addEnvironmental = false;
 						}
 						if (addEnvironmental)
-							Base::World::EnvironmentalData::TempData::t_environmentalMessages.push_back(Base::World::EnvironmentalData::TempData::t_environmental);
+							Base::World::EnvironmentalData::TempData::t_environmentalMessages.push_back(
+							Base::World::EnvironmentalData::TempData::t_environmental);
 						return original(unkn1);
 					});
+				*/
 				//怪物地址获取
 				HookLambda(MH::Monster::ctor,
 					[](auto monster, auto id, auto subId) {
@@ -875,8 +884,6 @@ namespace Base {
 				return false;
 			}
 		}
-		else
-			return true;
 	}
 	//实时更新的数据
 	static void RealTimeUpdate() {
@@ -910,7 +917,6 @@ namespace Base {
 				BasicGameData::PlayerPlot = *offsetPtr<undefined**>((undefined(*)())PlayerPlot, 0x50);
 			}
 			//更新玩家数据
-			/*
 			PlayerData::Updata();
 			//清除死亡的环境生物
 			for (auto [Environmental, EData] : World::EnvironmentalData::Environmentals) {
@@ -953,8 +959,10 @@ namespace Base {
 					Base::Monster::Monsters[monster].CoordinatesZ = *offsetPtr<float>(monster, 0x168);
 				}
 			}
+
 			//更新计时器时间
 			Chronoscope::NowTime = *offsetPtr<float>(BasicGameData::MapPlot, 0xC24);
+
 			//检查相机计时器
 			if (!Chronoscope::CheckChronoscope("SetVisual")) {
 				if(!PlayerData::Coordinate::TempData::t_LockVisual)
@@ -973,7 +981,6 @@ namespace Base {
 			}
 			//运行委托
 			Commission::Run();
-			*/
 		}
 	}
 }

--- a/deps/ghidra_export.h
+++ b/deps/ghidra_export.h
@@ -42,8 +42,7 @@ namespace MH {
         static undefined(*Visual)() = (undefined(*)())0x141FBB736;
     }
     namespace EnvironmentalBiological {
-        static undefined* (*ctor)(undefined*, undefined*, undefined*, undefined*) = (undefined * (*)(undefined*, undefined*, undefined*, undefined*))0x141D45935;
-        static undefined* (*ctor_)(undefined) = (undefined * (*)(undefined))0x141d45d39;
+        static undefined * (*ctor)(undefined*, undefined4, undefined4) = (undefined * (*)(undefined*, undefined4, undefined4))0x141D442C0;
     }
     namespace World {
         static undefined8(*WaypointZLocal)(float*, float*) = (undefined8(*)(float*, float*))0x141DBF55F;

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -19,7 +19,7 @@
 
 #include "Base.h"
 #include "Execution.h"
-//#include "LuaScript.h"
+#include "LuaScript.h"
 
 using namespace loader;
 vector<string> LuaFiles;
@@ -45,13 +45,11 @@ __declspec(dllexport) extern bool Load()
 			if (Base::Init()) {
 				Base::RealTimeUpdate();
 				//Execution::Main();
-				/*
 				if (Base::ModConfig::GameDataInit) {
 					for (string file_name : LuaFiles) {
 						Lua_Main(file_name);
 					}
 				}
-				*/
 			}
 			return ret;
 		});

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -19,7 +19,7 @@
 
 #include "Base.h"
 #include "Execution.h"
-#include "LuaScript.h"
+//#include "LuaScript.h"
 
 using namespace loader;
 vector<string> LuaFiles;
@@ -45,11 +45,13 @@ __declspec(dllexport) extern bool Load()
 			if (Base::Init()) {
 				Base::RealTimeUpdate();
 				//Execution::Main();
+				/*
 				if (Base::ModConfig::GameDataInit) {
 					for (string file_name : LuaFiles) {
 						Lua_Main(file_name);
 					}
 				}
+				*/
 			}
 			return ret;
 		});

--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -45,7 +45,7 @@ __declspec(dllexport) extern bool Load()
 			if (Base::Init()) {
 				Base::RealTimeUpdate();
 				//Execution::Main();
-				if (false and Base::ModConfig::GameDataInit) {
+				if (Base::ModConfig::GameDataInit) {
 					for (string file_name : LuaFiles) {
 						Lua_Main(file_name);
 					}


### PR DESCRIPTION
通过对环境生物初始化生成地址方式的修改，修复了闪退的问题，目前环境生物通过生成时钩子进行初始化，建议找到吊销钩子后将环境生物吊销的方式也改为钩子执行